### PR TITLE
Fix network scanner to ensure no errors and professional grade

### DIFF
--- a/network_scanner.py
+++ b/network_scanner.py
@@ -22,6 +22,8 @@ from tqdm import tqdm
 import colorama
 from colorama import init, Fore, Style
 import random
+import os
+import shutil
 
 # Initialize colorama for cross-platform colored output
 init()
@@ -297,6 +299,16 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
+
+    # Check for root privileges
+    if os.geteuid() != 0:
+        logging.error("This script must be run with root privileges.")
+        sys.exit(1)
+
+    # Check if nmap is installed
+    if not shutil.which("nmap"):
+        logging.error("nmap program was not found in path. Please install nmap and ensure it is in your PATH.")
+        sys.exit(1)
     
     try:
         scanner = EnhancedNetworkScanner(


### PR DESCRIPTION
Add checks for root privileges and nmap installation, and improve error handling in `network_scanner.py`.

* **Root Privileges Check**
  - Add a check to ensure the script is run with root privileges at the beginning of the `main` function.
  - Log an error message and exit if the script is not run with root privileges.

* **nmap Installation Check**
  - Add a check to ensure the `nmap` program is installed and in the system's PATH at the beginning of the `main` function.
  - Log an error message and exit if `nmap` is not found.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Anon23261/NetworkScanner/pull/2?shareId=b45182a0-a064-409d-a01e-1784abab1bc8).